### PR TITLE
Fix infinite spinner

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,16 +33,13 @@ module.exports = function({ startDate, endDate, workdaysOnly, commitsPerDay }) {
 
     const sortedList = commitDateList.sort(compareAsc);
 
-    await sortedList.reduce(async (prevPromise, date) => {
-      await prevPromise;
+    const command = sortedList
+      .map(date => {
+        return `echo "${date}" > ${filename}; git add ${filename}; git commit --date "${date}" -m "fake commit"`;
+      })
+      .join(";");
 
-      return execAsync(
-        `echo "${date}" > ${filename}; git add ${filename}; git commit --date "${date}" -m "fake commit"`,
-        {
-          encoding: "utf8"
-        }
-      );
-    }, Promise.resolve());
+    await execAsync(command, { encoding: "utf8" });
 
     spinner.succeed();
 


### PR DESCRIPTION
Fixes #2.

A potential solution is joining all the git commands into a single long command and running it once asynchronously. This guarantees that the commands run individually in sequence (and therefore without race conditions), but also collectively run in an asynchronous fashion so that the spinner doesn't freeze. Here it is in action:

<img width="1393" alt="Screen Shot 2019-08-22 at 01 55 23" src="https://user-images.githubusercontent.com/11808903/63476100-f31a7980-c47f-11e9-8849-4a6a9b8f9914.png">