### PR TITLE
Implementation of the exec() call in Promise mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,9 @@ module.exports = function(props) {
 
     if (os.platform() === "win32") {
       for (const date of commitDateList) {
-        await sleep(150);
-        exec(`echo "${date}" > ${filename}`);
-        exec(`git add .`);
-        exec(`git commit --quiet --date "${date}" -m "fake commit"`);
+        await execShellCommand(`echo "${date}" > ${filename}`);
+        await execShellCommand(`git add .`);
+        await execShellCommand(`git commit --quiet --date "${date}" -m "fake commit"`);
       }
     } else {
       const command = commitDateList
@@ -69,6 +68,23 @@ module.exports = function(props) {
     );
   })();
 
+  /**
+   * Executes a shell command and return it as a Promise.
+   * @param cmd {string}
+   * @return {Promise<string>}
+   */
+  function execShellCommand(cmd) {
+    const exec = require('child_process').exec;
+    return new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+      console.warn(error);
+      }
+      resolve(stdout? stdout : stderr);
+    });
+    });
+  }
+  
   function generateCommitDateList({
     commitsPerDay,
     workdaysOnly,


### PR DESCRIPTION
I don't know why I had this problem, but I noticed that I always had a limit of 1 to 3 commits for each day using the --commitsPerDay option "5,10" (see screen) however in the debug the value commitsPerDay was always higher than 3 and in the commit creation loop there were the X commits sent. however during a "git log" only 3 commits maximum per day were present. So I suspect a problem with the exec() and the waiting of 150. I solved the problem by using an exec in Promise mode.

![image](https://user-images.githubusercontent.com/6824137/99575694-452ab180-29d9-11eb-9fd2-477a94790c58.png)
